### PR TITLE
✨ feat: Add poster endpoints (create, list, edit, delete); serve admi…

### DIFF
--- a/app/core/entities.py
+++ b/app/core/entities.py
@@ -358,4 +358,24 @@ class PendingUserInfo(BaseModel):
                 "email": "john.doe@example.com",
                 "created_at": "2024-01-15T10:30:00Z"
             }
+        }
+
+class Poster(BaseModel):
+    """Poster domain entity"""
+    id: int
+    username: str
+    message: str
+    image_path: str
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+        schema_extra = {
+            "example": {
+                "id": 1,
+                "username": "john_doe",
+                "message": "Check out my new poster!",
+                "image_path": "/uploads/poster1.jpg",
+                "created_at": "2024-06-29T10:30:00Z"
+            }
         } 

--- a/app/infrastructure/models.py
+++ b/app/infrastructure/models.py
@@ -41,4 +41,14 @@ class RefreshTokenModel(Base):
     token = Column(String(500), primary_key=True, index=True)
     username = Column(String(50), nullable=False, index=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
-    expires_at = Column(DateTime(timezone=True), nullable=False) 
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+
+class PosterModel(Base):
+    """Poster database model (image + message)"""
+    __tablename__ = "posters"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String(50), nullable=False, index=True)
+    message = Column(Text, nullable=False)
+    image_path = Column(String(500), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now()) 

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -143,7 +143,7 @@ initialize_database() {
     sleep 5
     
     # Run database setup
-    python database_setup.py
+    python database/database_setup.py
     
     print_success "Database initialized successfully"
 }

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
 import asyncio
+from fastapi.staticfiles import StaticFiles
 
 from app.api.routes import router
 from app.infrastructure.database import init_db, close_db
@@ -132,6 +133,9 @@ app.add_middleware(
 
 # Include API routes
 app.include_router(router, prefix="/api/v1")
+
+# Serve the admin directory at /admin
+app.mount("/admin", StaticFiles(directory="admin"), name="admin")
 
 def custom_openapi():
     """Custom OpenAPI schema with enhanced documentation"""


### PR DESCRIPTION
…n static files; fix SQLAlchemy and Pydantic v2 compatibility

   - Users can create posters with image and message
   - Posters are saved to SQL and images to uploads/
   - Add endpoints to edit and delete posters (owner only)
   - Serve /admin static files for admin interface
   - Fix Pydantic v2 from_orm usage
   - Fix SQLAlchemy async attribute access and file handling
   - Update docker-setup.sh to use correct database setup path
   - General bugfixes and linter error fixes

   This commit is signed for verified authorship.