### PR TITLE
feat(realtime): notify clients on new public/community posts & refactor post form

### DIFF
--- a/app/infrastructure/notifier.py
+++ b/app/infrastructure/notifier.py
@@ -1,0 +1,33 @@
+from typing import List
+
+from fastapi import WebSocket, WebSocketDisconnect
+
+
+class PostNotifier:
+    def __init__(self):
+        self.active_connections: List[WebSocket] = []
+        self.usernames: dict = {}  # websocket -> username
+
+    async def connect(self, websocket: WebSocket, username: str = ""):
+        await websocket.accept()
+        self.active_connections.append(websocket)
+        if username:
+            self.usernames[websocket] = username
+
+    def disconnect(self, websocket: WebSocket):
+        if websocket in self.active_connections:
+            self.active_connections.remove(websocket)
+        if websocket in self.usernames:
+            del self.usernames[websocket]
+
+    async def broadcast_new_post(self, poster_username: str):
+        # Notify all except the poster
+        for ws in list(self.active_connections):
+            try:
+                if self.usernames.get(ws) != poster_username:
+                    await ws.send_json({"event": "new_post"})
+            except Exception:
+                self.disconnect(ws)
+
+
+post_notifier = PostNotifier()

--- a/frontend/src/components/PostFormModal.jsx
+++ b/frontend/src/components/PostFormModal.jsx
@@ -1,0 +1,254 @@
+import React, { useState } from "react";
+import Modal from "./Modal";
+
+export default function PostFormModal({ open, onClose, onSuccess }) {
+  const [formImage, setFormImage] = useState(null);
+  const [formImageUrl, setFormImageUrl] = useState("");
+  const [formMessage, setFormMessage] = useState("");
+  const [formPrivacy, setFormPrivacy] = useState("public");
+  const [formLoading, setFormLoading] = useState(false);
+  const [formError, setFormError] = useState("");
+
+  function handleImageChange(e) {
+    const file = e.target.files[0];
+    setFormImage(file);
+    if (file) {
+      const url = URL.createObjectURL(file);
+      setFormImageUrl(url);
+    } else {
+      setFormImageUrl("");
+    }
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setFormError("");
+    if (!formImage) {
+      setFormError("Vui lòng chọn ảnh!");
+      return;
+    }
+    if (!formMessage.trim()) {
+      setFormError("Vui lòng nhập lời nhắn!");
+      return;
+    }
+    setFormLoading(true);
+    try {
+      const formData = new FormData();
+      formData.append("image", formImage);
+      formData.append("message", formMessage);
+      formData.append("privacy", formPrivacy);
+      const res = await fetch("/api/v1/posters/", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem("access_token")}`,
+        },
+        body: formData,
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.detail || "Lỗi đăng bài");
+      }
+      setFormImage(null);
+      setFormImageUrl("");
+      setFormMessage("");
+      setFormPrivacy("private");
+      setFormLoading(false);
+      if (onSuccess) onSuccess();
+      if (onClose) onClose();
+    } catch (e) {
+      setFormError(e.message);
+      setFormLoading(false);
+    }
+  }
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <form
+        onSubmit={handleSubmit}
+        style={{
+          background: "#fff",
+          border: "1px solid #eee",
+          borderRadius: 12,
+          boxShadow: "0 2px 8px #7C4DFF11",
+          padding: 24,
+          marginBottom: 32,
+          width: "100%",
+          maxWidth: 500,
+          display: "flex",
+          flexDirection: "column",
+          gap: 16,
+          position: "relative",
+        }}
+      >
+        <div
+          style={{
+            fontWeight: 600,
+            fontSize: 20,
+            marginBottom: 8,
+            color: "var(--color-on-background, #222)",
+          }}
+        >
+          Đăng bài viết mới
+        </div>
+        <input
+          type="file"
+          accept="image/*"
+          onChange={handleImageChange}
+          disabled={formLoading}
+        />
+        {formImageUrl && (
+          <img
+            src={formImageUrl}
+            alt="Preview"
+            style={{
+              width: "100%",
+              maxHeight: 300,
+              objectFit: "cover",
+              borderRadius: 8,
+            }}
+          />
+        )}
+        <textarea
+          placeholder="Nhập lời nhắn..."
+          value={formMessage}
+          onChange={(e) => setFormMessage(e.target.value)}
+          rows={3}
+          style={{
+            padding: 16,
+            borderRadius: 8,
+            border: "2px solid #bdbdbd",
+            fontSize: 16,
+            resize: "vertical",
+            color: "var(--color-on-background, #222)",
+            background: "#fff",
+            outline: "none",
+            boxShadow: "0 1px 4px #0001",
+            transition: "border 0.2s",
+          }}
+          onFocus={(e) => (e.target.style.border = "2px solid #7c4dff")}
+          onBlur={(e) => (e.target.style.border = "2px solid #bdbdbd")}
+          disabled={formLoading}
+        />
+        {/* Chọn privacy */}
+        <div
+          style={{
+            display: "flex",
+            gap: 16,
+            alignItems: "center",
+            color: "var(--color-on-background, #222)",
+          }}
+        >
+          <span>Quyền riêng tư:</span>
+          <label
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 4,
+              background: "#e3f2fd",
+              color: "#1565c0",
+              borderRadius: 8,
+              padding: "2px 10px",
+              fontWeight: 500,
+            }}
+          >
+            <input
+              type="radio"
+              name="privacy"
+              value="public"
+              checked={formPrivacy === "public"}
+              onChange={() => setFormPrivacy("public")}
+              disabled={formLoading}
+              style={{ accentColor: "#1565c0" }}
+            />
+            Công khai
+          </label>
+          <label
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 4,
+              background: "#e8f5e9",
+              color: "#388e3c",
+              borderRadius: 8,
+              padding: "2px 10px",
+              fontWeight: 500,
+            }}
+          >
+            <input
+              type="radio"
+              name="privacy"
+              value="community"
+              checked={formPrivacy === "community"}
+              onChange={() => setFormPrivacy("community")}
+              disabled={formLoading}
+              style={{ accentColor: "#388e3c" }}
+            />
+            Cộng đồng
+          </label>
+          <label
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 4,
+              background: "#ffebee",
+              color: "#b71c1c",
+              borderRadius: 8,
+              padding: "2px 10px",
+              fontWeight: 500,
+            }}
+          >
+            <input
+              type="radio"
+              name="privacy"
+              value="private"
+              checked={formPrivacy === "private"}
+              onChange={() => setFormPrivacy("private")}
+              disabled={formLoading}
+              style={{ accentColor: "#b71c1c" }}
+            />
+            Riêng tư
+          </label>
+        </div>
+        {formError && (
+          <div style={{ color: "var(--color-error)", marginBottom: 8 }}>
+            {formError}
+          </div>
+        )}
+        <div style={{ display: "flex", gap: 12 }}>
+          <button
+            type="button"
+            onClick={onClose}
+            style={{
+              background: "#eee",
+              color: "var(--color-on-background, #222)",
+              border: "none",
+              borderRadius: 6,
+              padding: "8px 20px",
+              fontSize: 16,
+              cursor: "pointer",
+            }}
+            disabled={formLoading}
+          >
+            Huỷ
+          </button>
+          <button
+            type="submit"
+            style={{
+              background: "var(--color-primary,#7C4DFF)",
+              color: "#fff",
+              border: "none",
+              borderRadius: 6,
+              padding: "8px 20px",
+              fontSize: 16,
+              cursor: "pointer",
+              fontWeight: 500,
+            }}
+            disabled={formLoading}
+          >
+            {formLoading ? "Đang đăng..." : "Đăng bài"}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -4,6 +4,7 @@ import fetchWithAuth from "../utils/fetchWithAuth";
 import PostItem from "../components/PostItem";
 import PostDetail from "../components/PostDetail";
 import Modal from "../components/Modal";
+import PostFormModal from "../components/PostFormModal";
 
 export default function Home() {
   const navigate = useNavigate();
@@ -11,12 +12,7 @@ export default function Home() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [showForm, setShowForm] = useState(false);
-  const [formImage, setFormImage] = useState(null);
-  const [formImageUrl, setFormImageUrl] = useState("");
-  const [formMessage, setFormMessage] = useState("");
-  const [formLoading, setFormLoading] = useState(false);
-  const [formError, setFormError] = useState("");
-  const [formPrivacy, setFormPrivacy] = useState("public");
+  const [hasNewPost, setHasNewPost] = useState(false);
   const [selectedPost, setSelectedPost] = useState(null);
 
   useEffect(() => {
@@ -33,59 +29,55 @@ export default function Home() {
       })
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
-  }, [navigate, formLoading]);
-
-  // Xử lý chọn ảnh
-  function handleImageChange(e) {
-    const file = e.target.files[0];
-    setFormImage(file);
-    if (file) {
-      const url = URL.createObjectURL(file);
-      setFormImageUrl(url);
-    } else {
-      setFormImageUrl("");
-    }
-  }
-
-  // Xử lý đăng bài
-  async function handleSubmit(e) {
-    e.preventDefault();
-    setFormError("");
-    if (!formImage) {
-      setFormError("Vui lòng chọn ảnh!");
-      return;
-    }
-    if (!formMessage.trim()) {
-      setFormError("Vui lòng nhập lời nhắn!");
-      return;
-    }
-    setFormLoading(true);
-    try {
-      const formData = new FormData();
-      formData.append("image", formImage);
-      formData.append("message", formMessage);
-      formData.append("privacy", formPrivacy);
-      const res = await fetchWithAuth(
-        "/api/v1/posters/",
-        {
-          method: "POST",
-          body: formData,
-        },
-        navigate,
-      );
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.detail || "Lỗi đăng bài");
+    // WebSocket notification for new posts
+    let ws;
+    let closed = false;
+    function getUsernameFromToken() {
+      try {
+        const token = localStorage.getItem("access_token");
+        if (!token) return "";
+        const payload = JSON.parse(atob(token.split(".")[1]));
+        return payload.username || "";
+      } catch {
+        return "";
       }
-      setShowForm(false);
-      setFormImage(null);
-      setFormImageUrl("");
-      setFormMessage("");
-      setFormPrivacy("private");
-      setFormLoading(false);
+    }
+    const username = getUsernameFromToken();
+    function connectWS() {
+      ws = new window.WebSocket(
+        `${window.location.protocol === "https:" ? "wss" : "ws"}://${window.location.host}/ws/posts/notify?username=${encodeURIComponent(username)}`,
+      );
+      ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          if (data.event === "new_post") {
+            setHasNewPost(true);
+          }
+        } catch {}
+      };
+      ws.onclose = () => {
+        if (!closed) setTimeout(connectWS, 2000); // reconnect
+      };
+    }
+    connectWS();
+    return () => {
+      closed = true;
+      if (ws) ws.close();
+    };
+  }, [navigate]);
+
+  // Xử lý đăng bài thành công: reload post
+  async function reloadPosts() {
+    setLoading(true);
+    try {
+      const res = await fetchWithAuth("/api/v1/posters/", {}, navigate);
+      if (!res.ok) throw new Error("Lỗi tải danh sách bài viết");
+      const data = await res.json();
+      setPosts(data);
     } catch (e) {
-      setFormError(e.message);
-      setFormLoading(false);
+      setError(e.message);
+    } finally {
+      setLoading(false);
     }
   }
 
@@ -182,194 +174,49 @@ export default function Home() {
           Đăng bài viết
         </button>
       </div>
-      {/* Form đăng bài */}
-      {showForm && (
-        <form
-          onSubmit={handleSubmit}
-          style={{
-            background: "#fff",
-            border: "1px solid #eee",
-            borderRadius: 12,
-            boxShadow: "0 2px 8px #7C4DFF11",
-            padding: 24,
-            marginBottom: 32,
-            width: "100%",
-            maxWidth: 500,
-            display: "flex",
-            flexDirection: "column",
-            gap: 16,
-            position: "relative",
-          }}
-        >
-          <div
-            style={{
-              fontWeight: 600,
-              fontSize: 20,
-              marginBottom: 8,
-              color: "var(--color-on-background, #222)",
+      {/* Popup đăng bài viết */}
+      <PostFormModal
+        open={showForm}
+        onClose={() => setShowForm(false)}
+        onSuccess={reloadPosts}
+      />
+      {/* Nút thông báo có bài viết mới */}
+      {hasNewPost && (
+        <div style={{ margin: "16px 0" }}>
+          <button
+            onClick={async () => {
+              setLoading(true);
+              setHasNewPost(false);
+              try {
+                const res = await fetchWithAuth(
+                  "/api/v1/posters/",
+                  {},
+                  navigate,
+                );
+                if (!res.ok) throw new Error("Lỗi tải danh sách bài viết");
+                const data = await res.json();
+                setPosts(data);
+              } catch (e) {
+                setError(e.message);
+              } finally {
+                setLoading(false);
+              }
             }}
-          >
-            Đăng bài viết mới
-          </div>
-          <input
-            type="file"
-            accept="image/*"
-            onChange={handleImageChange}
-            disabled={formLoading}
-          />
-          {formImageUrl && (
-            <img
-              src={formImageUrl}
-              alt="Preview"
-              style={{
-                width: "100%",
-                maxHeight: 300,
-                objectFit: "cover",
-                borderRadius: 8,
-              }}
-            />
-          )}
-          <textarea
-            placeholder="Nhập lời nhắn..."
-            value={formMessage}
-            onChange={(e) => setFormMessage(e.target.value)}
-            rows={3}
             style={{
-              padding: 16,
+              background: "#ffeb3b",
+              color: "#222",
+              border: "1px solid #fbc02d",
               borderRadius: 8,
-              border: "2px solid #bdbdbd",
+              padding: "8px 20px",
               fontSize: 16,
-              resize: "vertical",
-              color: "var(--color-on-background, #222)",
-              background: "#fff",
-              outline: "none",
-              boxShadow: "0 1px 4px #0001",
-              transition: "border 0.2s",
-            }}
-            onFocus={(e) => (e.target.style.border = "2px solid #7c4dff")}
-            onBlur={(e) => (e.target.style.border = "2px solid #bdbdbd")}
-            disabled={formLoading}
-          />
-          {/* Chọn privacy */}
-          <div
-            style={{
-              display: "flex",
-              gap: 16,
-              alignItems: "center",
-              color: "var(--color-on-background, #222)",
+              fontWeight: 600,
+              cursor: "pointer",
+              boxShadow: "0 2px 8px #fbc02d33",
             }}
           >
-            <span>Quyền riêng tư:</span>
-            <label
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 4,
-                background: "#e3f2fd",
-                color: "#1565c0",
-                borderRadius: 8,
-                padding: "2px 10px",
-                fontWeight: 500,
-              }}
-            >
-              <input
-                type="radio"
-                name="privacy"
-                value="public"
-                checked={formPrivacy === "public"}
-                onChange={() => setFormPrivacy("public")}
-                disabled={formLoading}
-                style={{ accentColor: "#1565c0" }}
-              />
-              Công khai
-            </label>
-            <label
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 4,
-                background: "#e8f5e9",
-                color: "#388e3c",
-                borderRadius: 8,
-                padding: "2px 10px",
-                fontWeight: 500,
-              }}
-            >
-              <input
-                type="radio"
-                name="privacy"
-                value="community"
-                checked={formPrivacy === "community"}
-                onChange={() => setFormPrivacy("community")}
-                disabled={formLoading}
-                style={{ accentColor: "#388e3c" }}
-              />
-              Cộng đồng
-            </label>
-            <label
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 4,
-                background: "#ffebee",
-                color: "#b71c1c",
-                borderRadius: 8,
-                padding: "2px 10px",
-                fontWeight: 500,
-              }}
-            >
-              <input
-                type="radio"
-                name="privacy"
-                value="private"
-                checked={formPrivacy === "private"}
-                onChange={() => setFormPrivacy("private")}
-                disabled={formLoading}
-                style={{ accentColor: "#b71c1c" }}
-              />
-              Riêng tư
-            </label>
-          </div>
-          {formError && (
-            <div style={{ color: "var(--color-error)", marginBottom: 8 }}>
-              {formError}
-            </div>
-          )}
-          <div style={{ display: "flex", gap: 12 }}>
-            <button
-              type="button"
-              onClick={() => setShowForm(false)}
-              style={{
-                background: "#eee",
-                color: "var(--color-on-background, #222)",
-                border: "none",
-                borderRadius: 6,
-                padding: "8px 20px",
-                fontSize: 16,
-                cursor: "pointer",
-              }}
-              disabled={formLoading}
-            >
-              Huỷ
-            </button>
-            <button
-              type="submit"
-              style={{
-                background: "var(--color-primary,#7C4DFF)",
-                color: "#fff",
-                border: "none",
-                borderRadius: 6,
-                padding: "8px 20px",
-                fontSize: 16,
-                cursor: "pointer",
-                fontWeight: 500,
-              }}
-              disabled={formLoading}
-            >
-              {formLoading ? "Đang đăng..." : "Đăng bài"}
-            </button>
-          </div>
-        </form>
+            Có bài viết mới, refresh lại
+          </button>
+        </div>
       )}
       <div style={{ width: "100%" }}>
         {posts.length === 0 && <div>Chưa có bài viết nào.</div>}


### PR DESCRIPTION
- Add WebSocket notification system for new posts (public/community only)
- Notify all connected clients except the post creator when a new public or community post is created
- Move PostNotifier logic to a dedicated module for better separation of concerns
- Refactor post creation form into a reusable PostFormModal component (React)
- Show post creation form as a popup modal instead of inline
- Clean up unused variables and code in Home.jsx after refactor
- Auto-format and lint codebase for both backend (Python) and frontend (React)
- Ensure notification only appears for users other than the post creator

BREAKING CHANGE: The post creation UI is now a popup modal. Notification logic is now handled via WebSocket and only triggers for public/community posts and for users other than the creator.