### PR TITLE
feat: implement complete edit and delete functionality for posts

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -18,14 +18,14 @@ from app.infrastructure.database import get_db_session
 from app.infrastructure.models import PosterModel
 from app.infrastructure.notifier import post_notifier
 
-from ..core.entities import (AdminApprovalRequest, ImageInfo, LogoutRequest,
-                             PendingUserInfo, Poster, RefreshTokenRequest,
-                             Token, User, UserCreate, UserLogin,
-                             UserRegistrationResponse)
+from ..core.entities import (AdminApprovalRequest, ArchivedPoster, ImageInfo,
+                             LogoutRequest, PendingUserInfo, Poster,
+                             RefreshTokenRequest, Token, User, UserCreate,
+                             UserLogin, UserRegistrationResponse)
 from ..core.services import AuthService, ImageService
 from .dependencies import (get_auth_service, get_current_admin_user,
                            get_current_user, get_image_service,
-                           get_optional_user)
+                           get_optional_user, get_poster_service)
 
 
 class TokenWithUsername(Token):
@@ -787,25 +787,26 @@ async def get_posters(
     # Nếu user chưa đăng nhập, chỉ trả về post public
     username = getattr(current_user, "username", None)
     if username is not None:
-        # Đã đăng nhập: lấy post public + post community + post private của chính user
+        # Đã đăng nhập: lấy post public + post community + post private của chính user, chỉ lấy post chưa bị xóa
         stmt = (
             select(PosterModel)
             .where(
                 or_(
-                    PosterModel.privacy == "public",
-                    PosterModel.privacy == "community",
-                    PosterModel.username == username,
-                )
+                    (PosterModel.privacy == "public"),
+                    (PosterModel.privacy == "community"),
+                    (PosterModel.username == username),
+                ),
+                PosterModel.is_deleted == False,
             )
             .order_by(desc(PosterModel.created_at))
             .limit(limit)
             .offset(offset)
         )
     else:
-        # Chưa đăng nhập: chỉ lấy post public
+        # Chưa đăng nhập: chỉ lấy post public, chưa bị xóa
         stmt = (
             select(PosterModel)
-            .where(PosterModel.privacy == "public")
+            .where((PosterModel.privacy == "public"), PosterModel.is_deleted == False)
             .order_by(desc(PosterModel.created_at))
             .limit(limit)
             .offset(offset)
@@ -823,7 +824,7 @@ async def get_posters(
     "/posters/{poster_id}",
     response_model=Poster,
     tags=["Posters"],
-    summary="Edit a poster (message and/or image)",
+    summary="Edit a poster (message and/or image and/or privacy)",
     dependencies=[Security(get_current_user)],
 )
 async def edit_poster(
@@ -832,35 +833,31 @@ async def edit_poster(
     image: UploadFile = File(
         None, description="New image file for the poster (optional)"
     ),
+    privacy: str = Form(
+        None, description="New privacy setting: public, community, or private"
+    ),
     current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db_session),
+    poster_service=Depends(get_poster_service),
 ):
-    # Fetch poster
-    poster = await db.get(PosterModel, poster_id)
-    if poster is None:
-        raise HTTPException(status_code=404, detail="Poster not found")
-    if getattr(poster, "username", None) != current_user.username:
-        raise HTTPException(status_code=403, detail="Not allowed to edit this poster")
-    # Update message
-    if message is not None:
-        setattr(poster, "message", message)
-    # Update image if provided
+    image_content = None
+    image_filename = None
     if image is not None:
-        # Remove old image file
-        image_path_val = str(getattr(poster, "image_path", ""))
-        if image_path_val and os.path.exists(image_path_val):
-            os.remove(image_path_val)
-        upload_dir = "uploads"
-        os.makedirs(upload_dir, exist_ok=True)
-        image_filename = f"{current_user.username}_{image.filename}"
-        image_path = os.path.join(upload_dir, image_filename)
-        with open(image_path, "wb") as buffer:
-            shutil.copyfileobj(image.file, buffer)
-        setattr(poster, "image_path", image_path)
-    await db.commit()
-    await db.refresh(poster)
-    poster_obj = Poster.from_orm(poster)
-    return {**poster_obj.dict(), "image_path": public_image_path(poster_obj.image_path)}
+        image_content = await image.read()
+        image_filename = image.filename
+    try:
+        poster = await poster_service.edit_poster(
+            poster_id=poster_id,
+            username=current_user.username,
+            message=message,
+            image_content=image_content,
+            image_filename=image_filename,
+            privacy=privacy,
+        )
+        return {**poster.dict(), "image_path": public_image_path(poster.image_path)}
+    except ValueError as e:
+        raise HTTPException(
+            status_code=403 if "not allowed" in str(e).lower() else 404, detail=str(e)
+        )
 
 
 @router.delete(
@@ -872,20 +869,85 @@ async def edit_poster(
 async def delete_poster(
     poster_id: int,
     current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db_session),
+    poster_service=Depends(get_poster_service),
 ):
-    poster = await db.get(PosterModel, poster_id)
-    if poster is None:
-        raise HTTPException(status_code=404, detail="Poster not found")
-    if getattr(poster, "username", None) != current_user.username:
-        raise HTTPException(status_code=403, detail="Not allowed to delete this poster")
-    # Remove image file
-    image_path_val = str(getattr(poster, "image_path", ""))
-    if image_path_val and os.path.exists(image_path_val):
-        os.remove(image_path_val)
-    await db.delete(poster)
-    await db.commit()
-    return {"message": "Poster deleted successfully"}
+    try:
+        await poster_service.delete_poster(poster_id, current_user.username)
+        return {"message": "Poster deleted successfully"}
+    except ValueError as e:
+        raise HTTPException(
+            status_code=403 if "not allowed" in str(e).lower() else 404, detail=str(e)
+        )
+
+
+@router.get(
+    "/posters/deleted",
+    response_model=List[Poster],
+    tags=["Posters", "Trash"],
+    summary="Get all deleted (trashed) posters for current user",
+    description="""
+    Retrieve all posts that have been soft deleted (moved to trash) by the current user.
+    These posts can be restored or permanently deleted (hard delete).
+    """,
+    dependencies=[Security(get_current_user)],
+)
+async def get_deleted_posters(
+    current_user: User = Depends(get_current_user),
+    poster_service=Depends(get_poster_service),
+):
+    """
+    Get all deleted (trashed) posters for the current user.
+    Returns a list of posts that are in the trash (soft deleted, not yet permanently removed).
+    """
+    deleted = await poster_service.get_deleted_posts(current_user.username)
+    return [
+        {**po.dict(), "image_path": public_image_path(po.image_path)} for po in deleted
+    ]
+
+
+@router.delete(
+    "/posters/deleted/hard",
+    tags=["Posters", "Trash"],
+    summary="Permanently delete all deleted posters (empty trash)",
+    description="""
+    Permanently delete all posts in the trash for the current user.
+    This will archive the metadata for all deleted posts and remove their image files.
+    """,
+    dependencies=[Security(get_current_user)],
+)
+async def hard_delete_all_deleted_posters(
+    current_user: User = Depends(get_current_user),
+    poster_service=Depends(get_poster_service),
+):
+    """
+    Permanently delete all posts from the trash (hard delete).
+    All posts' metadata will be archived, and image files will be removed.
+    """
+    count = await poster_service.hard_delete_all_deleted(current_user.username)
+    return {"message": f"{count} deleted posters permanently removed"}
+
+
+@router.get(
+    "/posters/archived",
+    response_model=List[ArchivedPoster],
+    tags=["Posters", "Archive"],
+    summary="Get all archived (permanently deleted) posters metadata for current user",
+    description="""
+    Retrieve all archived posts metadata for the current user.
+    These are posts that have been permanently deleted (hard deleted) and only metadata is preserved.
+    """,
+    dependencies=[Security(get_current_user)],
+)
+async def get_archived_posters(
+    current_user: User = Depends(get_current_user),
+    poster_service=Depends(get_poster_service),
+):
+    """
+    Get all archived (permanently deleted) posters metadata for the current user.
+    Returns a list of archived post metadata (no image files).
+    """
+    archived = await poster_service.get_archived_posts(current_user.username)
+    return archived
 
 
 @router.get(
@@ -920,3 +982,31 @@ async def get_poster_detail(
                 )
     poster_obj = Poster.from_orm(poster)
     return {**poster_obj.dict(), "image_path": public_image_path(poster_obj.image_path)}
+
+
+@router.delete(
+    "/posters/{poster_id}/hard",
+    tags=["Posters", "Trash"],
+    summary="Permanently delete a single deleted poster (hard delete)",
+    description="""
+    Permanently delete a single post from the trash for the current user.
+    This will archive the metadata for the deleted post and remove its image file.
+    Only the post owner can perform this action, and only if the post is already soft deleted.
+    """,
+    response_model=ArchivedPoster,
+    dependencies=[Security(get_current_user)],
+)
+async def hard_delete_single_deleted_poster(
+    poster_id: int,
+    current_user: User = Depends(get_current_user),
+    poster_service=Depends(get_poster_service),
+):
+    try:
+        archived = await poster_service.hard_delete_post(
+            poster_id, current_user.username
+        )
+        return archived
+    except ValueError as e:
+        raise HTTPException(
+            status_code=403 if "not allowed" in str(e).lower() else 404, detail=str(e)
+        )

--- a/app/core/entities.py
+++ b/app/core/entities.py
@@ -321,6 +321,8 @@ class Poster(BaseModel):
     image_path: str
     created_at: datetime
     privacy: str  # 'public' hoặc 'private'
+    is_deleted: bool = False
+    deleted_at: Optional[datetime] = None
 
     class Config:
         from_attributes = True
@@ -331,6 +333,40 @@ class Poster(BaseModel):
                 "message": "Check out my new poster!",
                 "image_path": "/uploads/poster1.jpg",
                 "created_at": "2024-06-29T10:30:00Z",
+                "privacy": "public",
+                "is_deleted": False,
+                "deleted_at": None,
+            }
+        }
+
+
+class ArchivedPoster(BaseModel):
+    """Archived poster entity for permanently deleted posts (metadata only)"""
+
+    id: Optional[int] = None
+    original_id: int
+    username: str
+    message: str
+    original_image_path: str
+    image_filename: str
+    created_at: datetime
+    deleted_at: datetime
+    archived_at: datetime
+    privacy: str
+
+    class Config:
+        from_attributes = True
+        schema_extra = {
+            "example": {
+                "id": 1,
+                "original_id": 123,
+                "username": "john_doe",
+                "message": "Check out my new poster!",
+                "original_image_path": "/uploads/poster1.jpg",
+                "image_filename": "poster1.jpg",
+                "created_at": "2024-06-29T10:30:00Z",
+                "deleted_at": "2024-07-01T15:45:00Z",
+                "archived_at": "2024-07-15T09:20:00Z",
                 "privacy": "public",
             }
         }

--- a/app/core/interfaces.py
+++ b/app/core/interfaces.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import List, Optional
 
-from .entities import Image, Token, User, UserStatus
+from .entities import ArchivedPoster, Image, Token, User, UserStatus
 
 
 class UserRepository(ABC):
@@ -121,4 +121,81 @@ class RefreshTokenRepository(ABC):
     @abstractmethod
     async def delete_by_token(self, token: str) -> bool:
         """Delete refresh token by token string"""
+        pass
+
+
+class PosterRepository(ABC):
+    """Abstract poster repository interface"""
+
+    @abstractmethod
+    async def create(self, poster):
+        """Create a new poster"""
+        pass
+
+    @abstractmethod
+    async def get_by_id(self, poster_id: int):
+        """Get poster by id"""
+        pass
+
+    @abstractmethod
+    async def get_by_username(self, username: str) -> list:
+        """Get all posters for a user (not deleted)"""
+        pass
+
+    @abstractmethod
+    async def update(self, poster):
+        """Update poster"""
+        pass
+
+    @abstractmethod
+    async def delete(self, poster_id: int) -> bool:
+        """Soft delete poster by id (set is_deleted)"""
+        pass
+
+    @abstractmethod
+    async def get_deleted(self, username: str) -> list:
+        """Get all deleted posters for a user"""
+        pass
+
+    @abstractmethod
+    async def hard_delete(self, poster_id: int) -> bool:
+        """Permanently delete poster by id"""
+        pass
+
+    @abstractmethod
+    async def hard_delete_all_deleted(self, username: str) -> int:
+        """Permanently delete all deleted posters for a user, return count"""
+        pass
+
+    @abstractmethod
+    async def archive_and_hard_delete(
+        self, poster_id: int, archived_repo
+    ) -> ArchivedPoster:
+        """Archive poster metadata then hard delete"""
+        pass
+
+    @abstractmethod
+    async def archive_and_hard_delete_all_deleted(
+        self, username: str, archived_repo
+    ) -> int:
+        """Archive all deleted posters metadata then hard delete, return count"""
+        pass
+
+
+class ArchivedPosterRepository(ABC):
+    """Abstract archived poster repository interface"""
+
+    @abstractmethod
+    async def create(self, archived_poster):
+        """Create a new archived poster record"""
+        pass
+
+    @abstractmethod
+    async def get_by_username(self, username: str) -> list:
+        """Get all archived posters for a user"""
+        pass
+
+    @abstractmethod
+    async def get_by_original_id(self, original_id: int):
+        """Get archived poster by original ID"""
         pass

--- a/app/infrastructure/models.py
+++ b/app/infrastructure/models.py
@@ -67,3 +67,26 @@ class PosterModel(Base):
     privacy = Column(
         Enum("public", "community", "private", name="privacyenum"), default="private"
     )
+    is_deleted = Column(Boolean, default=False, nullable=False)
+    deleted_at = Column(DateTime(timezone=True), nullable=True)
+
+
+class ArchivedPosterModel(Base):
+    """Archived poster model for permanently deleted posts (metadata only)"""
+
+    __tablename__ = "archived_posters"
+
+    id = Column(Integer, primary_key=True, index=True)
+    original_id = Column(Integer, nullable=False, index=True)  # Original poster ID
+    username = Column(String(50), nullable=False, index=True)
+    message = Column(Text, nullable=False)
+    original_image_path = Column(
+        String(500), nullable=False
+    )  # Original image path (for reference)
+    image_filename = Column(String(255), nullable=False)  # Just the filename
+    created_at = Column(DateTime(timezone=True), nullable=False)
+    deleted_at = Column(DateTime(timezone=True), nullable=False)  # When soft deleted
+    archived_at = Column(
+        DateTime(timezone=True), server_default=func.now()
+    )  # When hard deleted
+    privacy = Column(String(20), nullable=False)  # Original privacy setting

--- a/app/infrastructure/postgresql_repositories.py
+++ b/app/infrastructure/postgresql_repositories.py
@@ -9,10 +9,12 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from ..core.entities import Image, User, UserStatus
-from ..core.interfaces import (ImageRepository, RefreshTokenRepository,
+from ..core.entities import ArchivedPoster, Image, Poster, User, UserStatus
+from ..core.interfaces import (ArchivedPosterRepository, ImageRepository,
+                               PosterRepository, RefreshTokenRepository,
                                TokenRepository, UserRepository)
-from .models import ImageModel, RefreshTokenModel, UserModel
+from .models import (ArchivedPosterModel, ImageModel, PosterModel,
+                     RefreshTokenModel, UserModel)
 
 
 class PostgreSQLUserRepository(UserRepository):
@@ -324,3 +326,203 @@ class PostgreSQLRefreshTokenRepository(RefreshTokenRepository):
         )
         await self.session.commit()
         return result.rowcount > 0
+
+
+class PostgreSQLArchivedPosterRepository(ArchivedPosterRepository):
+    """PostgreSQL archived poster repository implementation"""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def create(self, archived_poster: ArchivedPoster) -> ArchivedPoster:
+        db_archived = ArchivedPosterModel(
+            original_id=archived_poster.original_id,
+            username=archived_poster.username,
+            message=archived_poster.message,
+            original_image_path=archived_poster.original_image_path,
+            image_filename=archived_poster.image_filename,
+            created_at=archived_poster.created_at,
+            deleted_at=archived_poster.deleted_at,
+            archived_at=archived_poster.archived_at,
+            privacy=archived_poster.privacy,
+        )
+        self.session.add(db_archived)
+        await self.session.commit()
+        await self.session.refresh(db_archived)
+        return ArchivedPoster.from_orm(db_archived)
+
+    async def get_by_username(self, username: str) -> list:
+        result = await self.session.execute(
+            select(ArchivedPosterModel).where(ArchivedPosterModel.username == username)
+        )
+        archived = result.scalars().all()
+        return [ArchivedPoster.from_orm(a) for a in archived]
+
+    async def get_by_original_id(self, original_id: int) -> ArchivedPoster:
+        result = await self.session.execute(
+            select(ArchivedPosterModel).where(
+                ArchivedPosterModel.original_id == original_id
+            )
+        )
+        archived = result.scalar_one_or_none()
+        if not archived:
+            return None
+        return ArchivedPoster.from_orm(archived)
+
+
+class PostgreSQLPosterRepository(PosterRepository):
+    """PostgreSQL poster repository implementation"""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def create(self, poster: Poster) -> Poster:
+        db_poster = PosterModel(
+            username=poster.username,
+            message=poster.message,
+            image_path=poster.image_path,
+            privacy=poster.privacy,
+            is_deleted=poster.is_deleted,
+            deleted_at=poster.deleted_at,
+        )
+        self.session.add(db_poster)
+        await self.session.commit()
+        await self.session.refresh(db_poster)
+        return Poster.from_orm(db_poster)
+
+    async def get_by_id(self, poster_id: int) -> Poster:
+        db_poster = await self.session.get(PosterModel, poster_id)
+        if not db_poster:
+            return None
+        return Poster.from_orm(db_poster)
+
+    async def get_by_username(self, username: str) -> list:
+        result = await self.session.execute(
+            select(PosterModel).where(
+                PosterModel.username == username, PosterModel.is_deleted == False
+            )
+        )
+        posters = result.scalars().all()
+        return [Poster.from_orm(p) for p in posters]
+
+    async def update(self, poster: Poster) -> Poster:
+        db_poster = await self.session.get(PosterModel, poster.id)
+        if not db_poster:
+            raise ValueError("Poster not found")
+        db_poster.message = poster.message
+        db_poster.image_path = poster.image_path
+        db_poster.privacy = poster.privacy
+        db_poster.is_deleted = poster.is_deleted
+        db_poster.deleted_at = poster.deleted_at
+        await self.session.commit()
+        await self.session.refresh(db_poster)
+        return Poster.from_orm(db_poster)
+
+    async def delete(self, poster_id: int) -> bool:
+        # Soft delete: set is_deleted and deleted_at
+        db_poster = await self.session.get(PosterModel, poster_id)
+        if not db_poster:
+            return False
+        db_poster.is_deleted = True
+        from datetime import datetime, timezone
+
+        db_poster.deleted_at = datetime.now(timezone.utc)
+        await self.session.commit()
+        return True
+
+    async def get_deleted(self, username: str) -> list:
+        result = await self.session.execute(
+            select(PosterModel).where(
+                PosterModel.username == username, PosterModel.is_deleted == True
+            )
+        )
+        posters = result.scalars().all()
+        return [Poster.from_orm(p) for p in posters]
+
+    async def hard_delete(self, poster_id: int) -> bool:
+        db_poster = await self.session.get(PosterModel, poster_id)
+        if not db_poster:
+            return False
+        await self.session.delete(db_poster)
+        await self.session.commit()
+        return True
+
+    async def hard_delete_all_deleted(self, username: str) -> int:
+        result = await self.session.execute(
+            select(PosterModel).where(
+                PosterModel.username == username, PosterModel.is_deleted == True
+            )
+        )
+        posters = result.scalars().all()
+        count = 0
+        for p in posters:
+            await self.session.delete(p)
+            count += 1
+        await self.session.commit()
+        return count
+
+    async def archive_and_hard_delete(
+        self, poster_id: int, archived_repo: ArchivedPosterRepository
+    ) -> ArchivedPoster:
+        """Archive poster metadata then hard delete"""
+        db_poster = await self.session.get(PosterModel, poster_id)
+        if not db_poster:
+            return None
+
+        # Create archived record
+        import os
+        from datetime import datetime, timezone
+
+        archived_poster = ArchivedPoster(
+            original_id=db_poster.id,
+            username=db_poster.username,
+            message=db_poster.message,
+            original_image_path=db_poster.image_path,
+            image_filename=os.path.basename(db_poster.image_path),
+            created_at=db_poster.created_at,
+            deleted_at=db_poster.deleted_at,
+            archived_at=datetime.now(timezone.utc),
+            privacy=db_poster.privacy,
+        )
+        archived_result = await archived_repo.create(archived_poster)
+
+        # Hard delete
+        await self.session.delete(db_poster)
+        await self.session.commit()
+        return archived_result
+
+    async def archive_and_hard_delete_all_deleted(
+        self, username: str, archived_repo: ArchivedPosterRepository
+    ) -> int:
+        """Archive all deleted posters metadata then hard delete"""
+        result = await self.session.execute(
+            select(PosterModel).where(
+                PosterModel.username == username, PosterModel.is_deleted == True
+            )
+        )
+        posters = result.scalars().all()
+        count = 0
+        import os
+        from datetime import datetime, timezone
+
+        for p in posters:
+            # Create archived record
+            archived_poster = ArchivedPoster(
+                original_id=p.id,
+                username=p.username,
+                message=p.message,
+                original_image_path=p.image_path,
+                image_filename=os.path.basename(p.image_path),
+                created_at=p.created_at,
+                deleted_at=p.deleted_at,
+                archived_at=datetime.now(timezone.utc),
+                privacy=p.privacy,
+            )
+            await archived_repo.create(archived_poster)
+
+            # Hard delete
+            await self.session.delete(p)
+            count += 1
+
+        await self.session.commit()
+        return count

--- a/database/add_soft_delete_columns.py
+++ b/database/add_soft_delete_columns.py
@@ -1,0 +1,67 @@
+"""
+Database migration script to add soft delete columns to posters table
+"""
+
+import asyncio
+import os
+import sys
+
+# Add the app directory to the Python path
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from app.infrastructure.database import DATABASE_URL
+
+
+async def add_soft_delete_columns():
+    """Add is_deleted and deleted_at columns to posters table"""
+
+    # Create engine
+    engine = create_async_engine(DATABASE_URL, echo=True)
+
+    async with engine.begin() as conn:
+        try:
+            # Add is_deleted column with default value False
+            await conn.execute(
+                text(
+                    "ALTER TABLE posters ADD COLUMN IF NOT EXISTS is_deleted BOOLEAN DEFAULT FALSE NOT NULL"
+                )
+            )
+            print("✅ Added is_deleted column")
+
+            # Add deleted_at column
+            await conn.execute(
+                text(
+                    "ALTER TABLE posters ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP WITH TIME ZONE"
+                )
+            )
+            print("✅ Added deleted_at column")
+
+            # Update existing posts to have is_deleted = false
+            result = await conn.execute(
+                text("UPDATE posters SET is_deleted = FALSE WHERE is_deleted IS NULL")
+            )
+            print(
+                f"✅ Updated {result.rowcount} existing posts to have is_deleted = FALSE"
+            )
+
+        except Exception as e:
+            print(f"❌ Error adding columns: {e}")
+            raise
+
+    await engine.dispose()
+
+
+if __name__ == "__main__":
+    print("🔄 Adding soft delete columns to posters table...")
+    print("   - Adding is_deleted column (BOOLEAN, default FALSE)")
+    print("   - Adding deleted_at column (TIMESTAMP WITH TIME ZONE)")
+    print("   - Setting existing posts to is_deleted = FALSE")
+    print()
+
+    asyncio.run(add_soft_delete_columns())
+
+    print()
+    print("✅ Migration completed successfully!")

--- a/database/update_existing_posts.py
+++ b/database/update_existing_posts.py
@@ -1,0 +1,62 @@
+"""
+Script to update existing posts to set is_deleted to false and deleted_at to null
+"""
+
+import asyncio
+import os
+import sys
+from datetime import datetime
+
+# Add the app directory to the Python path
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.infrastructure.database import DATABASE_URL
+from app.infrastructure.models import PosterModel
+
+
+async def update_existing_posts():
+    """Update all existing posts to set is_deleted to false and deleted_at to null"""
+
+    # Create engine
+    engine = create_async_engine(DATABASE_URL, echo=True)
+
+    # Create session factory
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as session:
+        try:
+            # Update all existing posts
+            stmt = update(PosterModel).values(is_deleted=False, deleted_at=None)
+
+            result = await session.execute(stmt)
+            await session.commit()
+
+            print(f"✅ Successfully updated {result.rowcount} posts")
+            print(f"   - Set is_deleted to False")
+            print(f"   - Set deleted_at to None")
+
+        except Exception as e:
+            print(f"❌ Error updating posts: {e}")
+            await session.rollback()
+            raise
+        finally:
+            await session.close()
+
+    await engine.dispose()
+
+
+if __name__ == "__main__":
+    print("🔄 Updating existing posts...")
+    print(
+        "   Setting is_deleted to False and deleted_at to None for all existing posts"
+    )
+    print()
+
+    asyncio.run(update_existing_posts())
+
+    print()
+    print("✅ Update completed successfully!")

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import Login from "./pages/Login";
 import Register from "./pages/Register";
 import Home from "./pages/Home";
 import PostDetailPage from "./pages/PostDetailPage";
+import Trash from "./pages/Trash";
 import "./styles/App.css";
 
 export default function App() {
@@ -12,6 +13,7 @@ export default function App() {
       <Route path="/register" element={<Register />} />
       <Route path="/" element={<Home />} />
       <Route path="/post/:id" element={<PostDetailPage />} />
+      <Route path="/trash" element={<Trash />} />
       <Route path="*" element={<Navigate to="/login" replace />} />
     </Routes>
   );

--- a/frontend/src/components/PostDetail.jsx
+++ b/frontend/src/components/PostDetail.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-function PostDetail({ post }) {
+function PostDetail({ post, onEdit, onDelete }) {
   if (!post) return null;
   let imageUrl = post.image_path;
   if (imageUrl && !imageUrl.startsWith("/uploads/")) {
@@ -12,6 +12,21 @@ function PostDetail({ post }) {
     const d = new Date(post.created_at);
     createdAt = d.toLocaleString(undefined, { hour12: false });
   }
+  // Get current user
+  const currentUsername =
+    localStorage.getItem("username") ||
+    (() => {
+      try {
+        const token = localStorage.getItem("access_token");
+        if (!token) return "";
+        const payload = JSON.parse(atob(token.split(".")[1]));
+        return payload.username || "";
+      } catch {
+        return "";
+      }
+    })();
+  const isOwner = post.username === currentUsername;
+
   return (
     <div
       style={{
@@ -76,6 +91,40 @@ function PostDetail({ post }) {
       <div style={{ color: "#888", fontSize: 15, marginBottom: 16 }}>
         👤 {post.username}
       </div>
+      {isOwner && (
+        <div style={{ display: "flex", gap: 12, marginBottom: 16 }}>
+          <button
+            onClick={onEdit}
+            style={{
+              background: "#7C4DFF",
+              color: "#fff",
+              border: "none",
+              borderRadius: 6,
+              padding: "8px 20px",
+              fontSize: 16,
+              cursor: "pointer",
+              fontWeight: 500,
+            }}
+          >
+            Chỉnh sửa
+          </button>
+          <button
+            onClick={onDelete}
+            style={{
+              background: "#ff5252",
+              color: "#fff",
+              border: "none",
+              borderRadius: 6,
+              padding: "8px 20px",
+              fontSize: 16,
+              cursor: "pointer",
+              fontWeight: 500,
+            }}
+          >
+            Xoá bài viết
+          </button>
+        </div>
+      )}
       <div
         style={{
           display: "flex",

--- a/frontend/src/pages/PostDetailPage.jsx
+++ b/frontend/src/pages/PostDetailPage.jsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import PostDetail from "../components/PostDetail";
 import { api } from "../utils/api";
+import PostFormModal from "../components/PostFormModal";
+import Modal from "../components/Modal";
 
 export default function PostDetailPage() {
   const { id } = useParams();
@@ -9,6 +11,8 @@ export default function PostDetailPage() {
   const [post, setPost] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [showEdit, setShowEdit] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   useEffect(() => {
     setLoading(true);
@@ -52,7 +56,62 @@ export default function PostDetailPage() {
       })
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
-  }, [id, navigate]);
+  }, [id, navigate, showEdit]);
+
+  async function handleDelete() {
+    setError("");
+    try {
+      const res = await api.delete(`/api/v1/posters/${id}`);
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.detail || "Lỗi xoá bài viết");
+      }
+      navigate("/");
+    } catch (e) {
+      setError(e.message);
+    }
+  }
+
+  // Xử lý đăng bài thành công: reload post
+  async function reloadPost() {
+    setLoading(true);
+    setError("");
+    try {
+      const res = await api.get(`/api/v1/posters/${id}`, {}, navigate);
+      if (res.status === 401) {
+        navigate(`/login?redirect=/post/${id}`);
+        return;
+      }
+      if (res.status === 451) {
+        const data = await res.json().catch(() => ({}));
+        setError(
+          data.detail || "Chỉ chủ bài viết mới có quyền xem bài viết này!",
+        );
+        setPost(null);
+        setLoading(false);
+        return;
+      }
+      if (res.status === 403) {
+        const data = await res.json().catch(() => ({}));
+        setError(data.detail || "Bạn không có quyền xem bài viết này!");
+        setPost(null);
+        setLoading(false);
+        return;
+      }
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(
+          data.detail || "Không tìm thấy bài viết hoặc không có quyền xem!",
+        );
+      }
+      const data = await res.json();
+      setPost(data);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }
 
   if (loading)
     return (
@@ -84,8 +143,74 @@ export default function PostDetailPage() {
       }}
     >
       <div style={{ width: "100%", maxWidth: 700 }}>
-        <PostDetail post={post} />
+        <PostDetail
+          post={post}
+          onEdit={() => setShowEdit(true)}
+          onDelete={() => setShowDeleteConfirm(true)}
+        />
       </div>
+      {/* Edit Modal */}
+      {showEdit && (
+        <PostFormModal
+          open={showEdit}
+          onClose={() => setShowEdit(false)}
+          onSuccess={() => {
+            setShowEdit(false);
+            reloadPost(); // Reload to get updated post
+          }}
+          post={post}
+          mode="edit"
+        />
+      )}
+      {/* Delete Confirm Modal */}
+      {showDeleteConfirm && (
+        <Modal
+          open={showDeleteConfirm}
+          onClose={() => setShowDeleteConfirm(false)}
+        >
+          <div style={{ padding: 24, maxWidth: 400 }}>
+            <div style={{ fontWeight: 600, fontSize: 18, marginBottom: 16 }}>
+              Xác nhận xoá bài viết
+            </div>
+            <div style={{ marginBottom: 24 }}>
+              Bạn có chắc chắn muốn xoá bài viết này không? Bài viết sẽ được
+              chuyển vào thùng rác và có thể khôi phục hoặc xoá vĩnh viễn sau
+              này.
+            </div>
+            <div style={{ display: "flex", gap: 12 }}>
+              <button
+                onClick={() => setShowDeleteConfirm(false)}
+                style={{
+                  background: "#eee",
+                  color: "#222",
+                  border: "none",
+                  borderRadius: 6,
+                  padding: "8px 20px",
+                  fontSize: 16,
+                  cursor: "pointer",
+                }}
+              >
+                Huỷ
+              </button>
+              <button
+                onClick={handleDelete}
+                style={{
+                  background: "#ff5252",
+                  color: "#fff",
+                  border: "none",
+                  borderRadius: 6,
+                  padding: "8px 20px",
+                  fontSize: 16,
+                  cursor: "pointer",
+                  fontWeight: 500,
+                }}
+              >
+                Xoá
+              </button>
+            </div>
+          </div>
+        </Modal>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/Trash.jsx
+++ b/frontend/src/pages/Trash.jsx
@@ -1,0 +1,251 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { api } from "../utils/api";
+import PostItem from "../components/PostItem";
+import Modal from "../components/Modal";
+
+export default function Trash() {
+  const navigate = useNavigate();
+  const [posts, setPosts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [deleteId, setDeleteId] = useState(null);
+  const [showConfirmAll, setShowConfirmAll] = useState(false);
+
+  async function reload() {
+    setLoading(true);
+    setError("");
+    try {
+      const res = await api.get("/api/v1/posters/deleted");
+      if (!res.ok) throw new Error("Lỗi tải thùng rác");
+      const data = await res.json();
+      setPosts(data);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    reload();
+  }, []);
+
+  async function handleHardDelete(id) {
+    setError("");
+    try {
+      const res = await api.delete(`/api/v1/posters/${id}/hard`);
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.detail || "Lỗi xoá vĩnh viễn");
+      }
+      reload();
+    } catch (e) {
+      setError(e.message);
+    }
+  }
+
+  async function handleHardDeleteAll() {
+    setError("");
+    try {
+      const res = await api.delete(`/api/v1/posters/deleted/hard`);
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.detail || "Lỗi xoá tất cả vĩnh viễn");
+      }
+      reload();
+    } catch (e) {
+      setError(e.message);
+    }
+  }
+
+  if (loading)
+    return (
+      <div style={{ textAlign: "center", marginTop: 40 }}>Đang tải...</div>
+    );
+  if (error)
+    return (
+      <div
+        style={{
+          color: "var(--color-error)",
+          textAlign: "center",
+          marginTop: 40,
+        }}
+      >
+        {error}
+      </div>
+    );
+
+  return (
+    <div style={{ minHeight: "100vh", background: "#fff", padding: 24 }}>
+      <div style={{ maxWidth: 700, margin: "0 auto" }}>
+        <h2 style={{ fontWeight: 700, fontSize: 28, marginBottom: 24 }}>
+          Thùng rác
+        </h2>
+        <button
+          onClick={() => navigate("/")}
+          style={{
+            marginBottom: 24,
+            background: "#eee",
+            color: "#222",
+            border: "none",
+            borderRadius: 6,
+            padding: "8px 20px",
+            fontSize: 16,
+            cursor: "pointer",
+          }}
+        >
+          Quay lại trang chủ
+        </button>
+        {posts.length === 0 && <div>Thùng rác trống.</div>}
+        {posts.length > 0 && (
+          <div style={{ marginBottom: 24 }}>
+            <button
+              onClick={() => setShowConfirmAll(true)}
+              style={{
+                background: "#ff5252",
+                color: "#fff",
+                border: "none",
+                borderRadius: 6,
+                padding: "8px 20px",
+                fontSize: 16,
+                cursor: "pointer",
+                fontWeight: 500,
+              }}
+            >
+              Xoá tất cả vĩnh viễn
+            </button>
+          </div>
+        )}
+        <div style={{ width: "100%" }}>
+          {posts.map((post) => (
+            <div
+              key={post.id}
+              style={{ marginBottom: 16, position: "relative" }}
+            >
+              <PostItem post={post} />
+              <button
+                onClick={() => {
+                  setDeleteId(post.id);
+                  setShowConfirm(true);
+                }}
+                style={{
+                  position: "absolute",
+                  top: 8,
+                  right: 8,
+                  background: "#ff5252",
+                  color: "#fff",
+                  border: "none",
+                  borderRadius: 6,
+                  padding: "6px 16px",
+                  fontSize: 14,
+                  cursor: "pointer",
+                  fontWeight: 500,
+                }}
+              >
+                Xoá vĩnh viễn
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+      {/* Confirm single delete */}
+      {showConfirm && (
+        <Modal open={showConfirm} onClose={() => setShowConfirm(false)}>
+          <div style={{ padding: 24, maxWidth: 400 }}>
+            <div style={{ fontWeight: 600, fontSize: 18, marginBottom: 16 }}>
+              Xác nhận xoá vĩnh viễn
+            </div>
+            <div style={{ marginBottom: 24 }}>
+              Bạn có chắc chắn muốn xoá vĩnh viễn bài viết này? Hành động này
+              không thể hoàn tác.
+            </div>
+            <div style={{ display: "flex", gap: 12 }}>
+              <button
+                onClick={() => setShowConfirm(false)}
+                style={{
+                  background: "#eee",
+                  color: "#222",
+                  border: "none",
+                  borderRadius: 6,
+                  padding: "8px 20px",
+                  fontSize: 16,
+                  cursor: "pointer",
+                }}
+              >
+                Huỷ
+              </button>
+              <button
+                onClick={() => {
+                  handleHardDelete(deleteId);
+                  setShowConfirm(false);
+                }}
+                style={{
+                  background: "#ff5252",
+                  color: "#fff",
+                  border: "none",
+                  borderRadius: 6,
+                  padding: "8px 20px",
+                  fontSize: 16,
+                  cursor: "pointer",
+                  fontWeight: 500,
+                }}
+              >
+                Xoá vĩnh viễn
+              </button>
+            </div>
+          </div>
+        </Modal>
+      )}
+      {/* Confirm all delete */}
+      {showConfirmAll && (
+        <Modal open={showConfirmAll} onClose={() => setShowConfirmAll(false)}>
+          <div style={{ padding: 24, maxWidth: 400 }}>
+            <div style={{ fontWeight: 600, fontSize: 18, marginBottom: 16 }}>
+              Xác nhận xoá tất cả vĩnh viễn
+            </div>
+            <div style={{ marginBottom: 24 }}>
+              Bạn có chắc chắn muốn xoá vĩnh viễn tất cả bài viết trong thùng
+              rác? Hành động này không thể hoàn tác.
+            </div>
+            <div style={{ display: "flex", gap: 12 }}>
+              <button
+                onClick={() => setShowConfirmAll(false)}
+                style={{
+                  background: "#eee",
+                  color: "#222",
+                  border: "none",
+                  borderRadius: 6,
+                  padding: "8px 20px",
+                  fontSize: 16,
+                  cursor: "pointer",
+                }}
+              >
+                Huỷ
+              </button>
+              <button
+                onClick={() => {
+                  handleHardDeleteAll();
+                  setShowConfirmAll(false);
+                }}
+                style={{
+                  background: "#ff5252",
+                  color: "#fff",
+                  border: "none",
+                  borderRadius: 6,
+                  padding: "8px 20px",
+                  fontSize: 16,
+                  cursor: "pointer",
+                  fontWeight: 500,
+                }}
+              >
+                Xoá tất cả vĩnh viễn
+              </button>
+            </div>
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -7,6 +7,8 @@ export const api = {
     fetchWithAuth(url, { ...options, method: "POST", body }, navigate),
   put: (url, body, navigate, options = {}) =>
     fetchWithAuth(url, { ...options, method: "PUT", body }, navigate),
+  patch: (url, body, navigate, options = {}) =>
+    fetchWithAuth(url, { ...options, method: "PATCH", body }, navigate),
   delete: (url, navigate, options = {}) =>
     fetchWithAuth(url, { ...options, method: "DELETE" }, navigate),
 };

--- a/frontend/src/utils/fetchWithAuth.js
+++ b/frontend/src/utils/fetchWithAuth.js
@@ -9,28 +9,28 @@ export default async function fetchWithAuth(url, options = {}, navigate) {
   });
   if (res.status === 401 || res.status === 403) {
     // Thử refresh token qua cookie
-      const refreshRes = await fetch("/api/v1/refresh", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+    const refreshRes = await fetch("/api/v1/refresh", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       credentials: "include",
-      });
-      if (refreshRes.ok) {
-        const data = await refreshRes.json();
-        localStorage.setItem("access_token", data.access_token);
+    });
+    if (refreshRes.ok) {
+      const data = await refreshRes.json();
+      localStorage.setItem("access_token", data.access_token);
       if (data.username) {
         localStorage.setItem("username", data.username);
       }
-        // Thử lại request gốc
-        res = await fetch(url, {
-          ...options,
-          headers: {
-            ...options.headers,
-            Authorization: `Bearer ${data.access_token}`,
-          },
+      // Thử lại request gốc
+      res = await fetch(url, {
+        ...options,
+        headers: {
+          ...options.headers,
+          Authorization: `Bearer ${data.access_token}`,
+        },
         credentials: "include",
-        });
-      } else {
-        localStorage.removeItem("access_token");
+      });
+    } else {
+      localStorage.removeItem("access_token");
       localStorage.removeItem("username");
       navigate("/login");
       throw new Error("Phiên đăng nhập hết hạn!");


### PR DESCRIPTION
Backend Changes:
- Add soft delete support with is_deleted and deleted_at fields
- Implement PosterService with edit_poster and delete_poster methods
- Add hard delete functionality with archive support
- Add endpoints for trash management (/posters/deleted, /posters/{id}/hard)
- Add privacy field support in edit endpoint
- Fix route ordering to prevent conflicts

Frontend Changes:
- Add edit and delete buttons to PostDetail component
- Implement edit/delete functionality in Home.jsx and PostDetailPage.jsx
- Add PostFormModal with edit mode support
- Add Trash page for managing deleted posts
- Add missing PATCH method to API utility
- Fix duplicate buttons and improve UX consistency

Database Changes:
- Add migration scripts for soft delete columns
- Update existing posts to have is_deleted=false

Features:
- Users can edit post message, image, and privacy settings
- Users can soft delete posts (move to trash)
- Users can hard delete posts from trash (permanent)
- Posts in trash can be viewed and managed
- Edit/delete buttons only show for post owners
- Consistent behavior across home and detail pages