### PR TITLE
feat(trash): add restore functionality for trashed posts

### DIFF
--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -182,7 +182,7 @@ async def get_optional_user(
     scheme, param = get_authorization_scheme_param(auth)
     if not auth or scheme.lower() != "bearer" or not param:
         return None
-    
+
     # Check if token is valid (not expired)
     try:
         username = auth_service.verify_token(param)

--- a/app/core/interfaces.py
+++ b/app/core/interfaces.py
@@ -153,6 +153,11 @@ class PosterRepository(ABC):
         pass
 
     @abstractmethod
+    async def restore(self, poster_id: int, username: str) -> bool:
+        """Restore a soft-deleted poster (set is_deleted to False)"""
+        pass
+
+    @abstractmethod
     async def get_deleted(self, username: str) -> list:
         """Get all deleted posters for a user"""
         pass

--- a/app/core/services.py
+++ b/app/core/services.py
@@ -528,3 +528,17 @@ class PosterService:
 
     async def get_archived_posts(self, username: str):
         return await self.archived_repo.get_by_username(username)
+
+    async def restore_post(self, poster_id: int, username: str):
+        poster = await self.poster_repo.get_by_id(poster_id)
+        if not poster:
+            raise ValueError("Poster not found")
+        if poster.username != username:
+            raise ValueError("Not allowed to restore this poster")
+        if not poster.is_deleted:
+            raise ValueError("Poster is not deleted")
+        success = await self.poster_repo.restore(poster_id, username)
+        if not success:
+            raise ValueError("Failed to restore poster")
+        # Return the restored poster
+        return await self.poster_repo.get_by_id(poster_id)

--- a/app/infrastructure/postgresql_repositories.py
+++ b/app/infrastructure/postgresql_repositories.py
@@ -526,3 +526,12 @@ class PostgreSQLPosterRepository(PosterRepository):
 
         await self.session.commit()
         return count
+
+    async def restore(self, poster_id: int, username: str) -> bool:
+        db_poster = await self.session.get(PosterModel, poster_id)
+        if not db_poster or db_poster.username != username or not db_poster.is_deleted:
+            return False
+        db_poster.is_deleted = False
+        db_poster.deleted_at = None
+        await self.session.commit()
+        return True

--- a/frontend/src/pages/Trash.jsx
+++ b/frontend/src/pages/Trash.jsx
@@ -146,6 +146,41 @@ export default function Trash() {
               >
                 Xoá vĩnh viễn
               </button>
+              <button
+                onClick={async () => {
+                  setError("");
+                  try {
+                    setLoading(true);
+                    const res = await api.patch(
+                      `/api/v1/posters/${post.id}/restore`,
+                    );
+                    if (!res.ok) {
+                      const data = await res.json().catch(() => ({}));
+                      throw new Error(data.detail || "Lỗi khôi phục bài viết");
+                    }
+                    reload();
+                  } catch (e) {
+                    setError(e.message);
+                  } finally {
+                    setLoading(false);
+                  }
+                }}
+                style={{
+                  position: "absolute",
+                  top: 8,
+                  right: 120,
+                  background: "#4caf50",
+                  color: "#fff",
+                  border: "none",
+                  borderRadius: 6,
+                  padding: "6px 16px",
+                  fontSize: 14,
+                  cursor: "pointer",
+                  fontWeight: 500,
+                }}
+              >
+                Khôi phục
+              </button>
             </div>
           ))}
         </div>

--- a/frontend/src/utils/fetchWithAuth.js
+++ b/frontend/src/utils/fetchWithAuth.js
@@ -1,4 +1,4 @@
-export default async function fetchWithAuth(url, options = {}, navigate) {
+export default async function fetchWithAuth(url, options = {}) {
   let res = await fetch(url, {
     ...options,
     headers: {
@@ -7,83 +7,54 @@ export default async function fetchWithAuth(url, options = {}, navigate) {
     },
     credentials: "include",
   });
-  
+
   if (res.status === 401 || res.status === 403) {
-<<<<<<< Updated upstream
-    // Thử refresh token qua cookie
-    const refreshRes = await fetch("/api/v1/refresh", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      credentials: "include",
-    });
-    if (refreshRes.ok) {
-      const data = await refreshRes.json();
-      localStorage.setItem("access_token", data.access_token);
-      if (data.username) {
-        localStorage.setItem("username", data.username);
-      }
-      // Thử lại request gốc
-      res = await fetch(url, {
-        ...options,
-        headers: {
-          ...options.headers,
-          Authorization: `Bearer ${data.access_token}`,
-        },
-        credentials: "include",
-      });
-    } else {
-      localStorage.removeItem("access_token");
-      localStorage.removeItem("username");
-      navigate("/login");
-      throw new Error("Phiên đăng nhập hết hạn!");
-=======
     // Token might be expired, try to refresh
-    const refreshToken = localStorage.getItem('refreshToken');
+    const refreshToken = localStorage.getItem("refresh_token");
     if (refreshToken) {
       try {
-        const refreshResponse = await fetch('/api/v1/refresh', {
-          method: 'POST',
-          credentials: 'include',
+        const refreshResponse = await fetch("/api/v1/refresh", {
+          method: "POST",
+          credentials: "include",
           headers: {
-            'Content-Type': 'application/json',
+            "Content-Type": "application/json",
           },
-          body: JSON.stringify({ refresh_token: refreshToken })
+          body: JSON.stringify({ refresh_token: refreshToken }),
         });
 
         if (refreshResponse.ok) {
           const refreshData = await refreshResponse.json();
-          localStorage.setItem('accessToken', refreshData.access_token);
-          
+          localStorage.setItem("access_token", refreshData.access_token);
+
           // Retry the original request with new token
-          const newHeaders = { ...headers };
+          const newHeaders = { ...options.headers };
           if (refreshData.access_token) {
-            newHeaders['Authorization'] = `Bearer ${refreshData.access_token}`;
+            newHeaders["Authorization"] = `Bearer ${refreshData.access_token}`;
           }
-          
+
           return fetch(url, { ...options, headers: newHeaders });
         } else {
           // Refresh failed, redirect to login
-          localStorage.removeItem('accessToken');
-          localStorage.removeItem('refreshToken');
-          window.location.href = '/login';
-          throw new Error('Authentication failed');
+          localStorage.removeItem("access_token");
+          localStorage.removeItem("refresh_token");
+          window.location.href = "/login";
+          throw new Error("Authentication failed");
         }
       } catch (error) {
         // Refresh failed, redirect to login
-        localStorage.removeItem('accessToken');
-        localStorage.removeItem('refreshToken');
-        window.location.href = '/login';
+        localStorage.removeItem("access_token");
+        localStorage.removeItem("refresh_token");
+        window.location.href = "/login";
         throw error;
       }
     } else {
       // No refresh token, redirect to login
-      localStorage.removeItem('accessToken');
-      localStorage.removeItem('refreshToken');
-      window.location.href = '/login';
-      throw new Error('No refresh token available');
->>>>>>> Stashed changes
+      localStorage.removeItem("access_token");
+      localStorage.removeItem("refresh_token");
+      window.location.href = "/login";
+      throw new Error("No refresh token available");
     }
   }
-  
+
   return res;
 }

--- a/test_expired_token.py
+++ b/test_expired_token.py
@@ -3,73 +3,72 @@
 Test script to verify expired token handling
 """
 
-import requests
 import json
 import time
 
+import requests
+
 BASE_URL = "http://localhost:8000"
 API_PREFIX = "/api/v1"
+
 
 def test_expired_token_handling():
     """Test that expired tokens properly trigger refresh mechanism"""
     print("🧪 Testing Expired Token Handling")
     print("=" * 50)
-    
+
     # 1. Login to get valid tokens
     print("\n1. Logging in with admin user...")
-    login_data = {
-        "username": "admin",
-        "password": "admin123"
-    }
-    
+    login_data = {"username": "admin", "password": "admin123"}
+
     response = requests.post(f"{BASE_URL}{API_PREFIX}/login", json=login_data)
     print(f"Login response: {response.status_code}")
-    
+
     if response.status_code != 200:
         print(f"Login error: {response.text}")
         return False
-    
+
     login_result = response.json()
     access_token = login_result.get("access_token")
     cookies = response.cookies
     print(f"Got access token: {access_token[:20]}...")
-    
+
     # 2. Test home page with valid token (should show all posts)
     print("\n2. Testing home page with valid token...")
     headers = {"Authorization": f"Bearer {access_token}"}
     response = requests.get(f"{BASE_URL}{API_PREFIX}/posters/", headers=headers)
     print(f"Home page response: {response.status_code}")
-    
+
     if response.status_code == 200:
         posts = response.json()
         print(f"Number of posts returned: {len(posts)}")
         if posts:
             print(f"First post privacy: {posts[0].get('privacy', 'unknown')}")
-    
+
     # 3. Test with expired token (manually create an expired token)
     print("\n3. Testing with expired token...")
     # Create a token that expires in 1 second
     expired_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhZG1pbiIsImlzX2FkbWluIjpmYWxzZSwiZXhwIjoxNzM0NzI4MDAwfQ.invalid_signature"
-    
+
     # Let's test with a completely invalid token first
     invalid_token = "invalid_token_here"
     headers = {"Authorization": f"Bearer {invalid_token}"}
-    
+
     response = requests.get(f"{BASE_URL}{API_PREFIX}/posters/", headers=headers)
     print(f"Home page with invalid token response: {response.status_code}")
-    
+
     if response.status_code == 401:
         print("✅ Correctly returned 401 for invalid token")
     else:
         print(f"❌ Expected 401, got {response.status_code}")
         print(f"Response: {response.text}")
-    
+
     # Now test with the expired token
     headers = {"Authorization": f"Bearer {expired_token}"}
-    
+
     response = requests.get(f"{BASE_URL}{API_PREFIX}/posters/", headers=headers)
     print(f"Home page with expired token response: {response.status_code}")
-    
+
     if response.status_code == 401:
         print("✅ Correctly returned 401 for expired token")
         return True
@@ -78,24 +77,26 @@ def test_expired_token_handling():
         print(f"Response: {response.text}")
         return False
 
+
 def test_frontend_refresh_mechanism():
     """Test the frontend refresh mechanism"""
     print("\n🧪 Testing Frontend Refresh Mechanism")
     print("=" * 50)
-    
+
     # This test would require a browser or frontend testing framework
     # For now, we'll just verify the backend behavior
     print("Frontend refresh mechanism test requires browser testing")
     print("The backend changes should now properly return 401 for expired tokens")
     print("which will trigger the frontend's fetchWithAuth refresh mechanism")
-    
+
     return True
+
 
 if __name__ == "__main__":
     try:
         success1 = test_expired_token_handling()
         success2 = test_frontend_refresh_mechanism()
-        
+
         if success1 and success2:
             print("\n✅ Expired token handling test completed successfully!")
             print("\n📝 Summary:")
@@ -105,4 +106,4 @@ if __name__ == "__main__":
         else:
             print("\n❌ Some tests failed!")
     except Exception as e:
-        print(f"\n❌ Test failed with exception: {e}") 
+        print(f"\n❌ Test failed with exception: {e}")

--- a/test_refresh_token.py
+++ b/test_refresh_token.py
@@ -3,70 +3,70 @@
 Test script to verify refresh token functionality
 """
 
-import requests
 import json
 import time
 
+import requests
+
 BASE_URL = "http://localhost:8000"
 API_PREFIX = "/api/v1"
+
 
 def test_refresh_token_flow():
     """Test the complete refresh token flow"""
     print("🧪 Testing Refresh Token Flow")
     print("=" * 50)
-    
+
     # 1. Login with default admin user
     print("\n1. Logging in with admin user...")
-    login_data = {
-        "username": "admin",
-        "password": "admin123"
-    }
-    
+    login_data = {"username": "admin", "password": "admin123"}
+
     response = requests.post(f"{BASE_URL}{API_PREFIX}/login", json=login_data)
     print(f"Login response: {response.status_code}")
-    
+
     if response.status_code != 200:
         print(f"Login error: {response.text}")
         return False
-    
+
     login_result = response.json()
     access_token = login_result.get("access_token")
     print(f"Got access token: {access_token[:20]}...")
-    
+
     # Check cookies
     cookies = response.cookies
     refresh_token_cookie = cookies.get("refresh_token")
     print(f"Refresh token cookie: {'Present' if refresh_token_cookie else 'Missing'}")
-    
+
     # 2. Test accessing protected endpoint
     print("\n2. Testing protected endpoint...")
     headers = {"Authorization": f"Bearer {access_token}"}
     response = requests.get(f"{BASE_URL}{API_PREFIX}/images", headers=headers)
     print(f"Protected endpoint response: {response.status_code}")
-    
+
     # 3. Test refresh token
     print("\n3. Testing refresh token...")
     refresh_response = requests.post(
         f"{BASE_URL}{API_PREFIX}/refresh",
         headers={"Content-Type": "application/json"},
-        cookies=cookies
+        cookies=cookies,
     )
-    
+
     print(f"Refresh response: {refresh_response.status_code}")
     if refresh_response.status_code == 200:
         refresh_result = refresh_response.json()
         new_access_token = refresh_result.get("access_token")
         print(f"Got new access token: {new_access_token[:20]}...")
-        
+
         # Test with new token
         headers = {"Authorization": f"Bearer {new_access_token}"}
         response = requests.get(f"{BASE_URL}{API_PREFIX}/images", headers=headers)
         print(f"Protected endpoint with new token: {response.status_code}")
-        
+
         return True
     else:
         print(f"Refresh error: {refresh_response.text}")
         return False
+
 
 if __name__ == "__main__":
     try:
@@ -76,4 +76,4 @@ if __name__ == "__main__":
         else:
             print("\n❌ Refresh token test failed!")
     except Exception as e:
-        print(f"\n❌ Test failed with exception: {e}") 
+        print(f"\n❌ Test failed with exception: {e}")


### PR DESCRIPTION
- Backend:
  - Add PATCH /api/v1/posters/{poster_id}/restore endpoint to restore soft-deleted (trashed) posters.
  - Implement restore logic in PosterRepository, PostgreSQLPosterRepository, and PosterService.
- Frontend:
  - Add Restore button for each post in Trash.jsx, calling the new restore endpoint.
- Chore:
  - Resolve merge conflict in fetchWithAuth.js to ensure proper token refresh and error handling.