### PR TITLE
feat(poster): support multi-image upload for posters

### DIFF
--- a/app/core/services/poster_service.py
+++ b/app/core/services/poster_service.py
@@ -28,8 +28,7 @@ class PosterService:
         poster_id: int,
         username: str,
         message: Optional[str] = None,
-        image_content: Optional[bytes] = None,
-        image_filename: Optional[str] = None,
+        image_updates: Optional[list] = None,
         privacy: Optional[str] = None,
     ):
         poster = await self.poster_repo.get_by_id(poster_id)
@@ -49,7 +48,7 @@ class PosterService:
             poster.privacy = privacy
 
         # Update image if provided
-        if image_content is not None and image_filename is not None:
+        if image_updates is not None:
             # Note: Image handling is now done in the route layer
             # since images are stored separately in the database
             pass

--- a/frontend/src/components/PostDetail.jsx
+++ b/frontend/src/components/PostDetail.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-function PostDetail({ post, onEdit, onDelete }) {
+function PostDetail({ post, onEdit, onDelete, initialImageIndex = 0 }) {
   if (!post) return null;
   let imageUrls = [];
   if (
@@ -31,6 +31,11 @@ function PostDetail({ post, onEdit, onDelete }) {
       }
     })();
   const isOwner = post.username === currentUsername;
+  const [carouselIdx, setCarouselIdx] = React.useState(initialImageIndex);
+
+  React.useEffect(() => {
+    setCarouselIdx(initialImageIndex);
+  }, [initialImageIndex]);
 
   return (
     <div
@@ -45,10 +50,118 @@ function PostDetail({ post, onEdit, onDelete }) {
         justifyContent: "center",
       }}
     >
-      {imageUrls.map((url) => (
+      {/* Carousel for images */}
+      {imageUrls.length > 1 ? (
+        <div style={{
+          width: "100%",
+          maxWidth: 600,
+          position: "relative",
+          marginBottom: 16,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center"
+        }}>
+          <button
+            onClick={() => setCarouselIdx((prev) => (prev - 1 + imageUrls.length) % imageUrls.length)}
+            style={{
+              position: "absolute",
+              left: 0,
+              top: "50%",
+              transform: "translateY(-50%)",
+              background: "rgba(255,255,255,0.7)",
+              border: "none",
+              borderRadius: "50%",
+              width: 36,
+              height: 36,
+              fontSize: 22,
+              fontWeight: 700,
+              cursor: "pointer",
+              zIndex: 2,
+              display: imageUrls.length > 1 ? "flex" : "none",
+              alignItems: "center",
+              justifyContent: "center",
+              padding: 0
+            }}
+            aria-label="Trước"
+          >
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M13 16L8 10L13 4" stroke="#7C4DFF" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"/>
+            </svg>
+          </button>
+          <div style={{
+            width: "100%",
+            maxWidth: 600,
+            overflow: "hidden",
+            borderRadius: 8,
+            background: "#fafafa"
+          }}>
+            <img
+              src={imageUrls[carouselIdx]}
+              alt={post.message}
+              style={{
+                width: "100%",
+                maxHeight: "55vh",
+                objectFit: "contain",
+                borderRadius: 8,
+                display: "block",
+                background: "#fafafa",
+                transition: "all 0.3s"
+              }}
+            />
+          </div>
+          <button
+            onClick={() => setCarouselIdx((prev) => (prev + 1) % imageUrls.length)}
+            style={{
+              position: "absolute",
+              right: 0,
+              top: "50%",
+              transform: "translateY(-50%)",
+              background: "rgba(255,255,255,0.7)",
+              border: "none",
+              borderRadius: "50%",
+              width: 36,
+              height: 36,
+              fontSize: 22,
+              fontWeight: 700,
+              cursor: "pointer",
+              zIndex: 2,
+              display: imageUrls.length > 1 ? "flex" : "none",
+              alignItems: "center",
+              justifyContent: "center",
+              padding: 0
+            }}
+            aria-label="Sau"
+          >
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M7 4L12 10L7 16" stroke="#7C4DFF" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"/>
+            </svg>
+          </button>
+          {/* Dots indicator */}
+          <div style={{
+            position: "absolute",
+            bottom: 8,
+            left: "50%",
+            transform: "translateX(-50%)",
+            display: "flex",
+            gap: 6
+          }}>
+            {imageUrls.map((_, idx) => (
+              <span
+                key={idx}
+                style={{
+                  width: 10,
+                  height: 10,
+                  borderRadius: "50%",
+                  background: idx === carouselIdx ? "#7C4DFF" : "#ccc",
+                  display: "inline-block"
+                }}
+              />
+            ))}
+          </div>
+        </div>
+      ) : imageUrls.length === 1 ? (
         <img
-          key={url}
-          src={url}
+          src={imageUrls[0]}
           alt={post.message}
           style={{
             width: "100%",
@@ -56,10 +169,10 @@ function PostDetail({ post, onEdit, onDelete }) {
             objectFit: "contain",
             borderRadius: 8,
             marginBottom: 16,
-            background: "#fafafa",
+            background: "#fafafa"
           }}
         />
-      ))}
+      ) : null}
       <div style={{ marginBottom: 8 }}>
         <span
           style={{

--- a/frontend/src/components/PostDetail.jsx
+++ b/frontend/src/components/PostDetail.jsx
@@ -1,6 +1,12 @@
 import React from "react";
 
 function PostDetail({ post, onEdit, onDelete, initialImageIndex = 0 }) {
+  // Đặt hooks ở đầu function
+  const [carouselIdx, setCarouselIdx] = React.useState(initialImageIndex);
+  React.useEffect(() => {
+    setCarouselIdx(initialImageIndex);
+  }, [initialImageIndex]);
+
   if (!post) return null;
   let imageUrls = [];
   if (
@@ -31,11 +37,6 @@ function PostDetail({ post, onEdit, onDelete, initialImageIndex = 0 }) {
       }
     })();
   const isOwner = post.username === currentUsername;
-  const [carouselIdx, setCarouselIdx] = React.useState(initialImageIndex);
-
-  React.useEffect(() => {
-    setCarouselIdx(initialImageIndex);
-  }, [initialImageIndex]);
 
   return (
     <div

--- a/frontend/src/components/PostFormModal.jsx
+++ b/frontend/src/components/PostFormModal.jsx
@@ -9,8 +9,10 @@ export default function PostFormModal({
   post = null,
   mode = "create",
 }) {
-  const [formImage, setFormImage] = useState(null);
-  const [formImageUrl, setFormImageUrl] = useState(post ? post.image_path : "");
+  const [formImages, setFormImages] = useState([]);
+  const [formImageUrls, setFormImageUrls] = useState(
+    post ? post.images.map((img) => img.file_path) : [],
+  );
   const [formMessage, setFormMessage] = useState(post ? post.message : "");
   const [formPrivacy, setFormPrivacy] = useState(
     post ? post.privacy : "public",
@@ -22,31 +24,31 @@ export default function PostFormModal({
     if (post) {
       setFormMessage(post.message || "");
       setFormPrivacy(post.privacy || "public");
-      setFormImageUrl(post.image_path || "");
-      setFormImage(null);
+      setFormImageUrls(post.images ? post.images.map((img) => img.file_path) : []);
+      setFormImages([]);
     } else {
       setFormMessage("");
       setFormPrivacy("public");
-      setFormImageUrl("");
-      setFormImage(null);
+      setFormImageUrls([]);
+      setFormImages([]);
     }
   }, [post, open]);
 
   function handleImageChange(e) {
-    const file = e.target.files[0];
-    setFormImage(file);
-    if (file) {
-      const url = URL.createObjectURL(file);
-      setFormImageUrl(url);
+    const files = Array.from(e.target.files);
+    setFormImages(files);
+    if (files.length > 0) {
+      const urls = files.map((file) => URL.createObjectURL(file));
+      setFormImageUrls(urls);
     } else {
-      setFormImageUrl(post ? post.image_path : "");
+      setFormImageUrls(post ? post.images.map((img) => img.file_path) : []);
     }
   }
 
   async function handleSubmit(e) {
     e.preventDefault();
     setFormError("");
-    if (mode === "create" && !formImage) {
+    if (mode === "create" && formImages.length === 0) {
       setFormError("Vui lòng chọn ảnh!");
       return;
     }
@@ -57,7 +59,11 @@ export default function PostFormModal({
     setFormLoading(true);
     try {
       const formData = new FormData();
-      if (formImage) formData.append("image", formImage);
+      if (formImages.length > 0) {
+        formImages.forEach((image) => {
+          formData.append("images", image);
+        });
+      }
       formData.append("message", formMessage);
       formData.append("privacy", formPrivacy);
       let res;
@@ -73,8 +79,8 @@ export default function PostFormModal({
             (mode === "edit" ? "Lỗi cập nhật bài viết" : "Lỗi đăng bài"),
         );
       }
-      setFormImage(null);
-      setFormImageUrl("");
+      setFormImages([]);
+      setFormImageUrls([]);
       setFormMessage("");
       setFormPrivacy("private");
       setFormLoading(false);
@@ -120,18 +126,24 @@ export default function PostFormModal({
           accept="image/*"
           onChange={handleImageChange}
           disabled={formLoading}
+          multiple
         />
-        {formImageUrl && (
-          <img
-            src={formImageUrl}
-            alt="Preview"
-            style={{
-              width: "100%",
-              maxHeight: 300,
-              objectFit: "cover",
-              borderRadius: 8,
-            }}
-          />
+        {formImageUrls.length > 0 && (
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            {formImageUrls.map((url, index) => (
+              <img
+                key={index}
+                src={url}
+                alt={`Preview ${index}`}
+                style={{
+                  width: 100,
+                  height: 100,
+                  objectFit: "cover",
+                  borderRadius: 8,
+                }}
+              />
+            ))}
+          </div>
         )}
         <textarea
           placeholder="Nhập lời nhắn..."

--- a/frontend/src/components/PostFormModal.jsx
+++ b/frontend/src/components/PostFormModal.jsx
@@ -105,10 +105,13 @@ export default function PostFormModal({
           marginBottom: 32,
           width: "100%",
           maxWidth: 500,
+          boxSizing: "border-box",
           display: "flex",
           flexDirection: "column",
           gap: 16,
           position: "relative",
+          maxHeight: "90vh",
+          overflowY: "auto",
         }}
       >
         <div
@@ -173,6 +176,7 @@ export default function PostFormModal({
             gap: 16,
             alignItems: "center",
             color: "var(--color-on-background, #222)",
+            flexWrap: "wrap",
           }}
         >
           <span>Quyền riêng tư:</span>

--- a/frontend/src/components/PostItem.jsx
+++ b/frontend/src/components/PostItem.jsx
@@ -1,15 +1,15 @@
 import React, { memo } from "react";
 
 const PostItem = memo(function PostItem({ post, onClick, showActions = true }) {
-  let imageUrl = "";
+  let imageUrls = [];
   if (
     Array.isArray(post.images) &&
     post.images.length > 0 &&
     post.images[0].file_path
   ) {
-    imageUrl = post.images[0].file_path;
+    imageUrls = post.images.map((img) => img.file_path);
   } else if (post.file_path || post.image_path) {
-    imageUrl = post.file_path || post.image_path;
+    imageUrls = [post.file_path || post.image_path];
   }
   let createdAt = "";
   if (post.created_at) {
@@ -18,7 +18,7 @@ const PostItem = memo(function PostItem({ post, onClick, showActions = true }) {
   }
   return (
     <div
-      onClick={onClick}
+      onClick={() => onClick(post)}
       style={{
         background: "var(--color-surface)",
         borderRadius: 12,
@@ -32,22 +32,74 @@ const PostItem = memo(function PostItem({ post, onClick, showActions = true }) {
         maxWidth: 600,
         cursor: "pointer",
         transition: "box-shadow 0.2s",
+        boxSizing: "border-box",
       }}
     >
-      <img
-        src={imageUrl}
-        alt={post.message}
-        style={{
-          width: "100%",
-          height: "auto",
-          borderRadius: 8,
-          marginBottom: 12,
-          objectFit: "cover",
-          aspectRatio: "4/3",
-          maxHeight: 400,
-        }}
-        loading="lazy"
-      />
+      {/* Image grid for up to 4 images */}
+      <div style={{
+        width: "100%",
+        display: "grid",
+        gridTemplateColumns: imageUrls.length > 1 ? "1fr 1fr" : "1fr",
+        gridTemplateRows: imageUrls.length > 2 ? "1fr 1fr" : "1fr",
+        gap: 6,
+        marginBottom: 12,
+        borderRadius: 8,
+        overflow: "hidden",
+        aspectRatio: imageUrls.length === 1 ? "4/3" : "1/1",
+        background: "#fafafa"
+      }}>
+        {imageUrls.slice(0, 4).map((url, idx) => (
+          <div key={url} style={{
+            position: "relative",
+            width: "100%",
+            height: "100%",
+            overflow: "hidden",
+            borderRadius: 8,
+            gridColumn: imageUrls.length === 3 && idx === 2 ? "1 / span 2" : undefined,
+            aspectRatio: imageUrls.length === 1 ? "4/3" : "1/1",
+            cursor: "pointer"
+          }}
+          onClick={e => {
+            e.stopPropagation();
+            onClick(post, idx);
+          }}
+          >
+            <img
+              src={url}
+              alt={post.message}
+              style={{
+                width: "100%",
+                height: "100%",
+                objectFit: "cover",
+                display: "block",
+                borderRadius: 8,
+                aspectRatio: imageUrls.length === 1 ? "4/3" : "1/1"
+              }}
+              loading="lazy"
+            />
+            {/* Overlay for more images */}
+            {idx === 3 && imageUrls.length > 4 && (
+              <div style={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                width: "100%",
+                height: "100%",
+                background: "rgba(0,0,0,0.45)",
+                color: "#fff",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: 32,
+                fontWeight: 700,
+                borderRadius: 8
+              }}>
+                +{imageUrls.length - 4}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
       <div
         style={{
           width: "100%",

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -19,6 +19,7 @@ export default function Home() {
   const [showForm, setShowForm] = useState(false);
   const [hasNewPost, setHasNewPost] = useState(false);
   const [selectedPost, setSelectedPost] = useState(null);
+  const [selectedImageIndex, setSelectedImageIndex] = useState(0);
   const [showEdit, setShowEdit] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [postToEdit, setPostToEdit] = useState(null);
@@ -56,6 +57,11 @@ export default function Home() {
       setShowDeleteConfirm(false);
       setPostToDelete(null);
     }
+  };
+
+  const handlePostClick = (post, imageIndex = 0) => {
+    setSelectedPost(post);
+    setSelectedImageIndex(imageIndex);
   };
 
   // Handle login
@@ -142,13 +148,14 @@ export default function Home() {
           <PostItem
             key={post.id}
             post={post}
-            onClick={() => setSelectedPost(post)}
+            onClick={handlePostClick}
           />
         ))}
         <Modal open={!!selectedPost} onClose={() => setSelectedPost(null)}>
           {selectedPost && (
             <PostDetail
               post={selectedPost}
+              initialImageIndex={selectedImageIndex}
               onEdit={
                 isAuthenticated ? () => handleEdit(selectedPost) : undefined
               }


### PR DESCRIPTION
- Update backend API to accept multiple images in create and edit poster endpoints
- Refactor route logic to save and associate multiple images per poster
- Update PosterService to handle image updates as a list
- Update frontend PostFormModal to allow selecting and previewing multiple images
- Adjust form submission to send all selected images to the backend
- Update UI to preview multiple images before posting or editing

BREAKING CHANGE: Poster creation and editing now use a multi-image API; frontend and API consumers must use the new `images` field (array of files) instead of a single `image`.