### PR TITLE
ci(jenkins): always pull latest master for release builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,6 +63,24 @@ pipeline {
             }
         }
 
+        stage('Ensure Latest Master for Release') {
+            when {
+                expression {
+                    def ENV_TYPE = readFile('envtype.txt').trim()
+                    return ENV_TYPE == 'release'
+                }
+            }
+            steps {
+                script {
+                    sh '''
+                        git fetch origin master
+                        git checkout master
+                        git reset --hard origin/master
+                    '''
+                }
+            }
+        }
+
         stage('Prepare .env') {
             steps {
                 script {


### PR DESCRIPTION
- Add 'Ensure Latest Master for Release' stage to Jenkinsfile.
- In release environment, force workspace to match latest origin/master using 'git fetch' and 'git reset --hard origin/master'.
- Ensure release deployments always use the newest code from master branch.